### PR TITLE
force MsUia::Window#child to instantiate an MsUia::Window as well

### DIFF
--- a/lib/rautomation/adapter/ms_uia/window.rb
+++ b/lib/rautomation/adapter/ms_uia/window.rb
@@ -355,7 +355,7 @@ module RAutomation
         # @param (see Window#initialize)
         # @return [RAutomation::Window] child window, popup or regular window.
         def child(locators)
-          RAutomation::Window.new Functions.child_window_locators(hwnd, locators)
+          RAutomation::Window.new Functions.child_window_locators(hwnd, locators).merge({:adapter => :ms_uia})
         end
 
         private

--- a/spec/adapter/ms_uia/window_spec.rb
+++ b/spec/adapter/ms_uia/window_spec.rb
@@ -91,17 +91,6 @@ describe "MsUia::Window", :if => SpecHelper.adapter == :ms_uia do
     box1.should == box2
   end
 
-  it "#child" do
-    window = RAutomation::Window.new(:title => /MainFormWindow/i)
-    window.should exist
-
-    # buttons are windows too. so let's find the button for now
-    child = window.child(:title => /About/i)
-    child.should exist
-    child.title.should == "&About"
-    #    child.text.should include "About"
-  end
-
   it "send tab keystrokes to move focus between elements" do
     window = RAutomation::Window.new(:title => /MainFormWindow/i)
     window.button(:value => "&About").set_focus
@@ -149,4 +138,18 @@ describe "MsUia::Window", :if => SpecHelper.adapter == :ms_uia do
     window.bounding_rectangle.should == [-4, -4, 1444, 874]
   end
 =end
+end
+
+describe "MsUia::Window#child" do
+  let(:window) {RAutomation::Window.new(:title => /MainFormWindow/i, :adapter => :ms_uia)}
+
+  it "#child" do
+    window.should exist
+
+    # buttons are windows too. so let's find the button for now
+    child = window.child(:title => /About/i)
+    child.should exist
+    child.title.should == "&About"
+    child.adapter.should eq(:ms_uia)
+  end
 end


### PR DESCRIPTION
When explicitly using a `:ms_uia` adapter in `RAutomation`, when accessing the `Window#child` method, you would get a `Window` object that called down into the `RAutomation::Adapter::Win32::Window` methods rather than a `RAutomation::Adapter::MsUia::Window` like the parent did.  This patch forces the `Window` returned from `Window#child` to be just like its parent.
### Example Usage

``` ruby
# assumes that RAUTOMATION_ADAPTER is NOT set to "ms_uia" (or not set at all)
window = RAutomation::Window.new :title => /Some Title/, :adapter => :ms_uia
child = window.child(:title => /About/)
# child.adapter == :ms_uia now, rather than :win32
```
### Notes

Since `SpecHelper` forces the "default" adapter for RAutomation when it runs, I had to do this outside of the normal `:if => SpecHelper.adapter == :ms_uia` filter.  The spec assumes that the `RAUTOMATION_ADAPTER` environment variable is not set on your machine (so that `:win32` is the default).
