### PR TITLE
Update FFI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ ipch
 *.opensdf
 _ReSharper*/
 packages/
+.vs/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,12 @@ PATH
   remote: .
   specs:
     rautomation (0.17.0)
-      ffi (~> 1.11)
+      ffi (~> 1.11.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    ffi (1.11.3)
     ffi (1.11.3-x86-mingw32)
     rake (0.9.2.2)
     rspec (2.14.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     rautomation (0.17.0)
-      ffi (~> 1.9.0)
+      ffi (~> 1.11)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    ffi (1.9.5)
-    ffi (1.9.5-x86-mingw32)
+    ffi (1.11.3)
+    ffi (1.11.3-x86-mingw32)
     rake (0.9.2.2)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -32,4 +32,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.15.4
+   2.0.1

--- a/ext/IAccessibleDLL/IAccessibleDLL/IAccessibleDLL.vcxproj
+++ b/ext/IAccessibleDLL/IAccessibleDLL/IAccessibleDLL.vcxproj
@@ -20,12 +20,14 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ext/UiaDll/UiaDll/UiaDll.vcxproj
+++ b/ext/UiaDll/UiaDll/UiaDll.vcxproj
@@ -22,12 +22,14 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/lib/rautomation/adapter/win_32/mouse.rb
+++ b/lib/rautomation/adapter/win_32/mouse.rb
@@ -25,9 +25,11 @@ module RAutomation
 
         def press
           send_input down_event
+          send_input down_event
         end
 
         def release
+          send_input up_event
           send_input up_event
         end
 

--- a/rautomation.gemspec
+++ b/rautomation.gemspec
@@ -26,7 +26,7 @@ RAutomation provides:
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]  
 
-  s.add_dependency("ffi", "~> 1.11")
+  s.add_dependency("ffi", "~> 1.11.0")
   s.add_development_dependency("rspec", "~> 2.14")
   s.add_development_dependency("rake")
   s.add_development_dependency("yard")

--- a/rautomation.gemspec
+++ b/rautomation.gemspec
@@ -26,7 +26,7 @@ RAutomation provides:
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]  
 
-  s.add_dependency("ffi", "~>1.9.0")
+  s.add_dependency("ffi", "~> 1.11")
   s.add_development_dependency("rspec", "~> 2.14")
   s.add_development_dependency("rake")
   s.add_development_dependency("yard")

--- a/spec/button_spec.rb
+++ b/spec/button_spec.rb
@@ -40,6 +40,8 @@ describe RAutomation::Button do
     button.should exist
     button.click
 
+    sleep(1)
+
     button.should_not exist
     window.should_not exist
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,8 +30,8 @@ module SpecHelper
                   # Path to some binary, which opens up a window, what can be
                   # minimized, maximized, activated, closed and etc.
                   :window1 => "ext\\WindowsForms\\Release\\WindowsForms.exe",
-                  :window2 => "calc",
-                  :window2_title => /calc/i,
+                  :window2 => "notepad",
+                  :window2_title => /notepad/i,
                   # Window 1 title, has to be a Regexp.
                   :window1_title => /FormWindow/i,
                   :window1_full_title => 'MainFormWindow',
@@ -55,8 +55,8 @@ module SpecHelper
                   # Path to some binary, which opens up a window, what can be
                   # minimized, maximized, activated, closed and etc.
                   :window1 => "ext\\WindowsForms\\Release\\WindowsForms.exe",
-                  :window2 => "calc",
-                  :window2_title => /calc/i,
+                  :window2 => "notepad",
+                  :window2_title => /notepad/i,
                   # Window 1 title, has to be a Regexp.
                   :window1_title => /FormWindow/i,
                   :window1_full_title => 'MainFormWindow',
@@ -81,8 +81,8 @@ module SpecHelper
                   # Path to some binary, which opens up a window, what can be
                   # minimized, maximized, activated, closed and etc.
                   :window1 => "ext\\WindowsForms\\Release\\WindowsForms.exe",
-                  :window2 => "calc",
-                  :window2_title => /calc/i,
+                  :window2 => "notepad",
+                  :window2_title => /notepad/i,
                   # Window 1 title, has to be a Regexp.
                   :window1_title => /FormWindow/i,
                   :window1_full_title => 'MainFormWindow',

--- a/spec/window_spec.rb
+++ b/spec/window_spec.rb
@@ -54,7 +54,7 @@ describe RAutomation::Window do
   it "#class_names" do
     window = RAutomation::Window.new(:title => SpecHelper::DATA[:window1_title])
 
-    fail "Expected class name not found." unless window.class_names.any? {|clazz| clazz.match(/WindowsForms10\.Window\.8\.app\.0\.2bf8098_r\d{2}_ad1/)}
+    fail "Expected class name not found." unless window.class_names.any? {|clazz| clazz.match(/WindowsForms10\.Window\.8\.app\.0\.\S+_r\d+_ad1/)}
 
     RAutomation::Window.wait_timeout = 0.1
     expect {RAutomation::Window.new(:title => "non-existing-window").class_names}.


### PR DESCRIPTION
This PR updates FFI to the current version, 1.11.3. Closes issue #125 
Since I only have VS2019 on my machine, I also updated the build tools.
Some of the specs were failing because it seems that the Win10 version of the calculator application spawns in a separate process that does not match the expected PID. Instead, I switched to spawning notepad processes, which behave as expected.

One oddity that I came across was the `press` and `release` mouse events were not working for me until I sent the messages a second time. I'm not sure if that is unique to my machine though. If that ends up not being needed I can remove the commit, but wanted to point it out. EDIT: I tested these changes on a Win7 box and the double press/release was not needed. So this problem seems to only be an issue on Win10.