### PR TITLE
Updated ffi dependency to 1.15.0

### DIFF
--- a/rautomation.gemspec
+++ b/rautomation.gemspec
@@ -26,7 +26,7 @@ RAutomation provides:
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]  
 
-  s.add_dependency("ffi", "~> 1.11.0")
+  s.add_dependency("ffi", "~> 1.15.0")
   s.add_development_dependency("rspec", "~> 2.14")
   s.add_development_dependency("rake")
   s.add_development_dependency("yard")


### PR DESCRIPTION
Request to update ffi version to 1.15.0 to make it available for Ruby 2.7 +