### PR TITLE
Ruby 3.x support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,6 +72,4 @@ task :default => "spec:all"
 
 task "release:source_control_push" => :spec
 
-task :release => %w[compile:all build:all]
-
 task :install => :build

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@ require 'bundler'
 require 'rspec/core/rake_task'
 require File.expand_path('../lib/rautomation/adapter/helper', __FILE__)
 
+Bundler::GemHelper.install_tasks
+
 namespace :compile do
   compile_tasks = [
     {:name => :uia_dll, :path => "UiaDll", :ext => "dll"},

--- a/Rakefile
+++ b/Rakefile
@@ -11,15 +11,14 @@ namespace :compile do
   ]
 
   compile_tasks.each do |compile_task|
-    full_ext_path = "ext/#{compile_task[:path]}/Release/#{compile_task[:path]}.#{compile_task[:ext]}"
-
-    %w[x86Release x64Release].each do |output_dir|
-      full_ext_path = full_ext_path.gsub(/(?<!x86|x64)Release/, output_dir) unless compile_task[:name] == :windows_forms
-      RAutomation::Adapter::Helper.build_solution(full_ext_path)
-    end
-
     desc "Compile #{compile_task[:path]}"
-    task compile_task[:name] => full_ext_path
+    task compile_task[:name] do
+      full_ext_path = "ext/#{compile_task[:path]}/Release/#{compile_task[:path]}.#{compile_task[:ext]}"
+      %w[x86Release x64Release].each do |output_dir|
+        ext_path = full_ext_path.gsub(/(?<!x86|x64)Release/, output_dir) unless compile_task[:name] == :windows_forms
+        RAutomation::Adapter::Helper.build_solution(ext_path)
+      end
+    end
   end
 
   desc "Compile all external dependencies"

--- a/Rakefile
+++ b/Rakefile
@@ -15,8 +15,8 @@ namespace :compile do
     task compile_task[:name] do
       full_ext_path = "ext/#{compile_task[:path]}/Release/#{compile_task[:path]}.#{compile_task[:ext]}"
       %w[x86Release x64Release].each do |output_dir|
-        ext_path = full_ext_path.gsub(/(?<!x86|x64)Release/, output_dir) unless compile_task[:name] == :windows_forms
-        RAutomation::Adapter::Helper.build_solution(ext_path)
+        full_ext_path = full_ext_path.gsub(/(?<!x86|x64)Release/, output_dir) unless compile_task[:name] == :windows_forms
+        RAutomation::Adapter::Helper.build_solution(full_ext_path)
       end
     end
   end

--- a/rautomation.gemspec
+++ b/rautomation.gemspec
@@ -20,26 +20,20 @@ RAutomation provides:
   s.license = "MIT"
   s.platform = Gem::Platform.local if s.platform == 'ruby'
 
-  ext_locations = [
-          "ext/IAccessibleDLL/Release/IAccessibleDLL.dll",
-          "ext/UiaDll/Release/UiaDll.dll",
-          "ext/UiaDll/Release/RAutomation.UIA.dll"
-  ]
-
-  winforms_files = Dir[
-          "ext/WindowsForms/Release/*.dll",
-          "ext/WindowsForms/Release/*.exe"
-  ]
-
-  RAutomation::Adapter::Helper.find_missing_externals(ext_locations).each do |ext|
-    RAutomation::Adapter::Helper.build_solution(ext)
+  missing_externals = RAutomation::Adapter::Helper.find_missing_externals
+  if missing_externals.any?
+    missing_externals.each { |ext_location | puts "Missing external: #{ext_location}" }
+    raise Gem::InstallError,
+          "One or more required DLL files are missing. See Rake task 'compile' in order to build."
   end
 
-  # move .dll files and get array containing paths
-  # send first three externals and first three characters from platform eg 'x86' from 'x86-mingw32'
-  externals = RAutomation::Adapter::Helper.move_adapter_dlls(ext_locations[0, 3], s.platform.to_s[0, 3])
+  ext_locations = RAutomation::Adapter::Helper::ADAPTER_DIRS
+  winforms_files = Dir[
+    "ext/WindowsForms/Release/*.dll",
+    "ext/WindowsForms/Release/*.exe"
+  ]
 
-  s.files         = `git ls-files`.split("\n") + externals + winforms_files
+  s.files         = `git ls-files`.split("\n") + ext_locations + winforms_files
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,8 +61,8 @@ module SpecHelper
                   # Path to some binary, which opens up a window, what can be
                   # minimized, maximized, activated, closed and etc.
                   window1: "ext\\WindowsForms\\Release\\WindowsForms.exe",
-                  window2: "notepad",
-                  window2_title: /notepad/i,
+                  window2: "regedit",
+                  window2_title: /registry editor/i,
                   # Window 1 title, has to be a Regexp.
                   window1_title: /FormWindow/i,
                   window1_full_title: 'MainFormWindow',


### PR DESCRIPTION
I have been working on adding functionality to build the gem for the mingw-ucrt platform.
In order to do that I have modified the Rakefile, made a "compile" task and modified the previously defined "build" task. 

The build task will iterate through the supported platforms, build the externals (if .dll is missing) and then move the DLLs from eg 'x86Release' -> 'Release' and then the gem is built. 

This results in 4 .gem files in the pkg directory, x86/x64-mingw + x86/x64-mingw-ucrt. 
These changes also means that the compilation and moving of files is all handled in the Rakefile, and the .gemspec only notifies for any missing DLLs. This does however mean that building the Gem is best done through the Rakefile, since running "gem build rautomation" will assume the DLLs are compiled and placed within their respective "Release" folder.

To compile and build the .gem files use rake task _build_ or _install_

Regarding the change from notepad to regedit in the specs I changed this because I was no longer able to interact with notepad on Windows 11. It seems like the UWP apps are containerized in some way and automating these has to be done with a different API

Apologies for the messy commit. I ended up doing too many things at once after parking the task for a bit. 
Let me know if you have any questions or suggestions regarding this update. 
